### PR TITLE
switch to resource + action pattern in logs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -52,7 +52,7 @@ async function run() {
       // await unzipFunctionCode(zipFilePath, serviceName, functionName);
       await writeFunctionConfigFile(functionConfig, serviceName, functionName);
 
-      console.log(`Deployed function ${service}-${fn}`);
+      console.log(`Function deployed: ${service}-${fn}`);
 
       ctx.response.type = 'json';
       ctx.body = ctx.request.body;
@@ -92,7 +92,7 @@ async function run() {
 
   app.listen(port, () => {
     // eslint-disable-next-line
-    console.log(`Local Emulator listening on http://localhost:${port}`);
+    console.log(`Local Emulator listening on: http://localhost:${port}`);
   });
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -48,7 +48,8 @@ async function run() {
       // await unzipFunctionCode(zipFilePath, functionId);
       await writeFunctionConfigFile(functionConfig, functionId);
 
-      console.log(`Function deployed: ${functionId}`); // eslint-disable-line
+      // eslint-disable-next-line
+      console.log(`Function deployed: ${functionId}`);
 
       ctx.response.type = 'json';
       ctx.body = ctx.request.body;

--- a/src/main.js
+++ b/src/main.js
@@ -47,6 +47,7 @@ async function run() {
       copyDirContentsSync(functionConfig.servicePath, functionCodeDirectoryPath);
       // await unzipFunctionCode(zipFilePath, functionId);
       await writeFunctionConfigFile(functionConfig, functionId);
+
       console.log(`Function deployed: ${functionId}`); // eslint-disable-line
 
       ctx.response.type = 'json';


### PR DESCRIPTION
In `serverless run` the log statements start with the action first.   Since there are more actions than concepts, it makes the line statements differ a lot and isn't great for readability.  When each statement starts with the resource (e.g., Function, Event, Subscription) it's super simple to follow what's happening with each resource and easier to scan the logs.